### PR TITLE
Don't squash the password if provided

### DIFF
--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -3,6 +3,7 @@
 date > /etc/vagrant_box_build_time
 
 SSH_USER=${SSH_USERNAME:-vagrant}
+SSH_PASS=${SSH_PASSWORD:-vagrant}
 SSH_USER_HOME=${SSH_USER_HOME:-/home/${SSH_USER}}
 VAGRANT_INSECURE_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
 
@@ -14,7 +15,7 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
         echo "==> Creating $SSH_USER user"
         /usr/sbin/groupadd $SSH_USER
         /usr/sbin/useradd $SSH_USER -g $SSH_USER -G sudo -d $SSH_USER_HOME --create-home
-        echo "${SSH_USER}:${SSH_USER}" | chpasswd
+        echo "${SSH_USER}:${SSH_PASS}" | chpasswd
     fi
 
     # Set up sudo


### PR DESCRIPTION
The create user portion of the script doesn't usually run in the
current implementation because the user is provisioned as part of the
deployment of the base Ubuntu image; nonetheless, the script is
broken as-is.