### PR TITLE
Vmware disk type and more explicit install option

### DIFF
--- a/script/vmware.sh
+++ b/script/vmware.sh
@@ -22,7 +22,7 @@ if [[ $PACKER_BUILDER_TYPE =~ vmware ]]; then
     tar zxf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
     VMWARE_TOOLS_MAJOR_VERSION=$(echo ${VMWARE_TOOLS_VERSION} | cut -d '.' -f 1)
     if [ "${VMWARE_TOOLS_MAJOR_VERSION}" -lt "10" ]; then
-        /tmp/vmware-tools-distrib/vmware-install.pl -d
+        /tmp/vmware-tools-distrib/vmware-install.pl --default EULA_AGREED=yes
     else
         /tmp/vmware-tools-distrib/vmware-install.pl -f
     fi

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -28,6 +28,7 @@
         "<enter>"
       ],
       "disk_size": "{{ user `disk_size` }}",
+      "disk_type_id": "{{user `disk_type_id`}}",
       "guest_os_type": "{{ user `vmware_guest_os_type` }}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -189,7 +190,7 @@
         "script/docker.sh",
         "script/cmtool.sh",
         "script/motd.sh",
-        "custom-script.sh",
+        "{{user `custom_script`}}",
         "script/minimize.sh",
         "script/cleanup.sh"
       ],
@@ -201,9 +202,10 @@
     "cm": "nocm",
     "cm_version": "",
     "cpus": "1",
-    "custom_script": ".",
+    "custom_script": "custom-script.sh",
     "desktop": "false",
     "disk_size": "65536",
+    "disk_type_id": "0",
     "docker": "false",
     "ftp_proxy": "{{env `ftp_proxy`}}",
     "headless": "",
@@ -232,4 +234,3 @@
     "vmware_guest_os_type": "ubuntu-64"
   }
 }
-


### PR DESCRIPTION
I've found when building boxes for VMware it can be useful for performance and sanity to set the disk type to pre-allocated or dynamically allocated depending on what I'm building it for based on whether it will be used by users (who want to grow it) or used by a system that never changes so I can get maximum performance by allocating the full size in a contiguous file.

Also changed the custom-script.sh to be set by a user variable but defaulted it to the same for backwards compatibility with the current behavior.