### PR TITLE
Using sudoers.d/vagrant instead of direct sudoers file

### DIFF
--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -20,7 +20,8 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
 
     # Set up sudo
     echo "==> Giving ${SSH_USER} sudo powers"
-    echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+    echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+    chmod 440 /etc/sudoers.d/vagrant
 
     # Fix stdin not being a tty
     if grep -q -E "^mesg n$" /root/.profile && sed -i "s/^mesg n$/tty -s \\&\\& mesg n/g" /root/.profile; then


### PR DESCRIPTION
Using best practise for sudoers files.

We need this change to puppet-manage ```/etc/sudoders``` without letting puppet know about vagrant.