### PR TITLE
Add desktop build for 16.04

### DIFF
--- a/script/desktop.sh
+++ b/script/desktop.sh
@@ -26,10 +26,8 @@ if [[ $DISTRIB_RELEASE == 12.04 ]]; then
 
     configure_ubuntu1204_autologin
 
-elif [[ $DISTRIB_RELEASE == 14.04 || $DISTRIB_RELEASE == 15.04 ]]; then
+elif [[ $DISTRIB_RELEASE == 14.04 || $DISTRIB_RELEASE == 15.04 || $DISTRIB_RELEASE == 16.04 ]]; then
     echo "==> Installing ubunutu-desktop"
-#    apt-get install -y --no-install-recommends ubuntu-desktop
-#    apt-get install -y gnome-terminal
     apt-get install -y ubuntu-desktop
 
     USERNAME=${SSH_USER}
@@ -41,10 +39,8 @@ elif [[ $DISTRIB_RELEASE == 14.04 || $DISTRIB_RELEASE == 15.04 ]]; then
     echo "# Enabling automatic login" >> $GDM_CUSTOM_CONFIG
     echo "AutomaticLoginEnable=True" >> $GDM_CUSTOM_CONFIG
     echo "AutomaticLoginEnable=${USERNAME}" >> $GDM_CUSTOM_CONFIG
-    
+
     echo "==> Configuring lightdm autologin"
-    #if [ -f $LIGHTDM_CONFIG ]; then
-        echo "[SeatDefaults]" >> $LIGHTDM_CONFIG
-        echo "autologin-user=${USERNAME}" >> $LIGHTDM_CONFIG
-    #fi
+    echo "[SeatDefaults]" >> $LIGHTDM_CONFIG
+    echo "autologin-user=${USERNAME}" >> $LIGHTDM_CONFIG
 fi

--- a/script/locale.sh
+++ b/script/locale.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "==> Setting LANG locale value"
+update-locale LANG=en_US.UTF-8

--- a/tpl/vagrantfile-ubuntu1604-desktop.tpl
+++ b/tpl/vagrantfile-ubuntu1604-desktop.tpl
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-ubuntu1604-desktop"
+    config.vm.box = "ubuntu1604-desktop"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = true
+        v.customize ["modifyvm", :id, "--memory", 1024]
+        v.customize ["modifyvm", :id, "--cpus", 1]
+        v.customize ["modifyvm", :id, "--vram", "256"]
+        v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+        v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    end
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.gui = true
+        v.vmx["memsize"] = "1024"
+        v.vmx["numvcpus"] = "1"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
+      end
+    end
+end

--- a/ubuntu1604-desktop.json
+++ b/ubuntu1604-desktop.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu1604-desktop.json ubuntu1604.json`",
+  "vm_name": "ubuntu1604-desktop",
+  "desktop": "true",
+  "memory": "1024",
+  "preseed": "preseed.cfg",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu1604-desktop.tpl"
+}

--- a/ubuntu1604.json
+++ b/ubuntu1604.json
@@ -192,6 +192,7 @@
         "script/parallels.sh",
         "script/docker.sh",
         "script/cmtool.sh",
+        "script/locale.sh",
         "script/motd.sh",
         "custom-script.sh",
         "script/minimize.sh",
@@ -236,4 +237,3 @@
     "vmware_guest_os_type": "ubuntu-64"
   }
 }
-


### PR DESCRIPTION
### Whats this do?
Adds a `desktop` build for Ubuntu 16.04. It uses the same setup as the other desktop builds

### Open Issues
- [x] The generated image has a default `LANG` of `en_US`. This stops Terminal from starting correctly (http://askubuntu.com/questions/608330/probelm-with-gnome-terminal-on-gnome-3-12-2). This needs to be set via the preseed or via a post install script. Solved by https://github.com/boxcutter/ubuntu/pull/51/commits/ed33391e10c627379dfa1f8e9a83118d05b682fd