### PR TITLE
Proposal: Fix Ubuntu 16.04 for VMware

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -15,7 +15,19 @@ fi
 # Ubuntu 12.04 & 14.04
 if [ -d "/var/lib/dhcp" ]; then
     rm /var/lib/dhcp/*
-fi 
+fi
+
+. /etc/lsb-release
+if [[ $DISTRIB_RELEASE == 16.04 ]]; then
+  # from https://github.com/cbednarski/packer-ubuntu/blob/master/scripts-1604/vm_cleanup.sh#L9-L15
+  # When booting with Vagrant / VMware the PCI slot is changed from 33 to 32.
+  # Instead of eth0 the interface is now called ens33 to mach the PCI slot, so we
+  # need to change the networking scripts to enable the correct interface.
+  #
+  # NOTE: After the machine is rebooted Packer will not be able to reconnect
+  # (Vagrant will be able to) so make sure this is done in your final provisioner.
+  sed -i "s/ens33/ens32/g" /etc/network/interfaces
+fi
 
 # Add delay to prevent "vagrant reload" from failing
 echo "pre-up sleep 2" >> /etc/network/interfaces

--- a/script/vmware.sh
+++ b/script/vmware.sh
@@ -3,43 +3,9 @@
 SSH_USERNAME=${SSH_USERNAME:-vagrant}
 
 if [[ $PACKER_BUILDER_TYPE =~ vmware ]]; then
-    echo "==> Installing VMware Tools"
-    # Assuming the following packages are installed
-    # apt-get install -y linux-headers-$(uname -r) build-essential perl
-
-    cd /tmp
-    mkdir -p /mnt/cdrom
-    mount -o loop /home/${SSH_USERNAME}/linux.iso /mnt/cdrom
-
-    VMWARE_TOOLS_PATH=$(ls /mnt/cdrom/VMwareTools-*.tar.gz)
-    VMWARE_TOOLS_VERSION=$(echo "${VMWARE_TOOLS_PATH}" | cut -f2 -d'-')
-    VMWARE_TOOLS_BUILD=$(echo "${VMWARE_TOOLS_PATH}" | cut -f3 -d'-')
-    VMWARE_TOOLS_BUILD=$(basename ${VMWARE_TOOLS_BUILD} .tar.gz)
-    echo "==> VMware Tools Path: ${VMWARE_TOOLS_PATH}"
-    echo "==> VMWare Tools Version: ${VMWARE_TOOLS_VERSION}"
-    echo "==> VMware Tools Build: ${VMWARE_TOOLS_BUILD}" 
-
-    tar zxf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
-    VMWARE_TOOLS_MAJOR_VERSION=$(echo ${VMWARE_TOOLS_VERSION} | cut -d '.' -f 1)
-    if [ "${VMWARE_TOOLS_MAJOR_VERSION}" -lt "10" ]; then
-        /tmp/vmware-tools-distrib/vmware-install.pl -d
-    else
-        /tmp/vmware-tools-distrib/vmware-install.pl -f
-    fi
-
-    rm /home/${SSH_USERNAME}/linux.iso
-    umount /mnt/cdrom
-    rmdir /mnt/cdrom
-    rm -rf /tmp/VMwareTools-*
-
-    VMWARE_TOOLBOX_CMD_VERSION=$(vmware-toolbox-cmd -v)
-    echo "==> Installed VMware Tools ${VMWARE_TOOLBOX_CMD_VERSION}" 
-
-    echo "==> Checking version of Ubuntu"
-    . /etc/lsb-release
-    if [[ $DISTRIB_RELEASE == 15.10 ]]; then
-      echo "==> Applying workaround for Ubuntu 15.10"
-      sed -i.orig 's/^Exec=.*/Exec=env VMWARE_USE_SHIPPED_LIBS=1 \/usr\/bin\/vmare-user/' /etc/vmware-tools/vmware-user.desktop
-      cat /etc/vmware-tools/vmware-user.desktop
-    fi
+    echo "==> Installing Open VM Tools"
+    # Install open-vm-tools so we can mount shared folders
+    apt-get install -y open-vm-tools
+    # Add /mnt/hgfs so the mount works automatically with Vagrant
+    mkdir /mnt/hgfs
 fi


### PR DESCRIPTION
This is a proposal to fix the ubuntu1604 template for VMware.

1. Install open-vm-tools instead of VMware tools #66
2. Fix the startup timeout #60 with a hack by @cbednarski 
I have tested this PR with Vagrant 1.8.1 / Vagrant VMware plugin 4.0.9 / VMware Fusion Pro 8.1:

I know that the `vmware.sh` should be more intelligent to support older Ubuntu versions. So this should be reviewed how to write the "if-else" block to decice which Ubuntu version still needs VMware Tools and from which version on we switch to the open-vm-tools.

```
$ vagrant up
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Cloning VMware VM: 'ubuntu1604'. This can take some time...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Starting the VMware VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 192.168.254.135:22
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Forwarding ports...
    default: -- 22 => 2200
==> default: Configuring network adapters within the VM...
==> default: Waiting for HGFS to become available...
==> default: Enabling and configuring shared folders...
    default: -- /Users/stefan/code/ubuntu/tst: /vagrant
~/code/ubuntu/tst on master*
$ ls -l
total 8
-rw-r--r--  1 stefan  staff  3056 Jun  2 08:50 Vagrantfile
~/code/ubuntu/tst on master*
$ vagrant ssh
Welcome to Ubuntu 16.04 LTS (GNU/Linux 4.4.0-21-generic x86_64)

 * Documentation:  https://help.ubuntu.com/
----------------------------------------------------------------
  Ubuntu 16.04 LTS                            built 2016-06-02
----------------------------------------------------------------
vagrant@vagrant:~$ ls -l /vagrant
total 3
-rw-r--r-- 1 vagrant vagrant 3056 Jun  2 06:50 Vagrantfile
vagrant@vagrant:~$ exit
logout
Connection to 192.168.254.135 closed.
$ vagrant version
Installed Version: 1.8.1
Latest Version: 1.8.1
 
You're running an up-to-date version of Vagrant!
~/code/ubuntu on fix-ubuntu1604-vmware
$ vagrant plugin list
vagrant-azure (1.3.0)
vagrant-digitalocean (0.9.0)
vagrant-multiprovider-snap (0.0.14)
vagrant-pristine (0.3.0)
vagrant-reload (0.0.1)
vagrant-share (1.1.5, system)
vagrant-vmware-fusion (4.0.9)
```
