### PR TITLE
Fix clean up for log files containing special character

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -39,7 +39,7 @@ rm -f /root/.bash_history
 rm -f /home/${SSH_USER}/.bash_history
 
 # Clean up log files
-find /var/log -type f | while read f; do echo -ne '' > $f; done;
+find /var/log -type f | while read f; do echo -ne '' > "${f}"; done;
 
 echo "==> Clearing last login information"
 >/var/log/lastlog


### PR DESCRIPTION
If the /var/log folder for example contains a file called '*.log' the cleanup.sh fails with the following bash error: ```ambiguous redirect```.