### PR TITLE
Disable unattended upgrades which are enabled by default in 16.04 (see #73)

### DIFF
--- a/script/update.sh
+++ b/script/update.sh
@@ -4,11 +4,13 @@
 echo "==> Disabling the release upgrader"
 sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
 
-# Disable unattended upgrades via systemd on 16.04, see issue #73
+# Disable unattended upgrades which are enabled in 16.04 by default, see issue #73
 if [[ $DISTRIB_RELEASE == 16.04 ]]; then
-    echo "==> Disabling unattended upgrades via systemd"
-    systemctl disable apt-daily.service
-    systemctl disable apt-daily.timer
+    echo "==> Disabling unattended upgrades"
+    cat << EOF > /etc/apt/apt.conf.d/51disable-unattended-upgrades
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
 fi
 
 echo "==> Updating list of repositories"

--- a/script/update.sh
+++ b/script/update.sh
@@ -4,6 +4,13 @@
 echo "==> Disabling the release upgrader"
 sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
 
+# Disable unattended upgrades via systemd on 16.04, see issue #73
+if [[ $DISTRIB_RELEASE == 16.04 ]]; then
+    echo "==> Disabling unattended upgrades via systemd"
+    systemctl disable apt-daily.service
+    systemctl disable apt-daily.timer
+fi
+
 echo "==> Updating list of repositories"
 # apt-get update does not actually perform updates, it just downloads and indexes the list of packages
 apt-get -y update

--- a/script/update.sh
+++ b/script/update.sh
@@ -4,6 +4,9 @@
 echo "==> Disabling the release upgrader"
 sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
 
+echo "==> Checking version of Ubuntu"
+. /etc/lsb-release
+
 # Disable unattended upgrades which are enabled in 16.04 by default, see issue #73
 if [[ $DISTRIB_RELEASE == 16.04 ]]; then
     echo "==> Disabling unattended upgrades"


### PR DESCRIPTION
That's my minimal attempt to fix #73

Have not tested it yet, but will trigger a packer build as soon as I have a stable internet connection

Btw: does this also run in some kind of internal CI build / test harness on your side? :)