### PR TITLE
Remove `vagrant` in file names

### DIFF
--- a/script/vagrant.sh
+++ b/script/vagrant.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-date > /etc/vagrant_box_build_time
+date > /etc/box_build_time
 
 SSH_USER=${SSH_USERNAME:-vagrant}
 SSH_PASS=${SSH_PASSWORD:-vagrant}
@@ -20,8 +20,8 @@ if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
 
     # Set up sudo
     echo "==> Giving ${SSH_USER} sudo powers"
-    echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-    chmod 440 /etc/sudoers.d/vagrant
+    echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/$SSH_USER
+    chmod 440 /etc/sudoers.d/$SSH_USER
 
     # Fix stdin not being a tty
     if grep -q -E "^mesg n$" /root/.profile && sed -i "s/^mesg n$/tty -s \\&\\& mesg n/g" /root/.profile; then


### PR DESCRIPTION
If you choose to build with a specific `SSH_USERNAME`, you mostly don't
want to have explicit vagrant-related stuff in your box