### PR TITLE
Add flexible custom script support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile.local
 .bundle/
 
 custom.sh
+script/custom/*
+!script/custom/.gitkeep

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ The variable `INSTALL_VAGRANT_KEY` can be set to turn off installation of the
 default insecure vagrant key when the image is being used outside of vagrant.
 Set `INSTALL_VAGRANT_KEY := false`, the default is true.
 
+The variable `CUSTOM_SCRIPT` can be used to specify a custom script
+to be executed. You can add it to the `script/custom` directory (content
+is ignored by Git).
+The default is `custom-script.sh` which does nothing.
+
 ## Contributing
 
 

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -174,7 +174,7 @@
         "script/virtualbox.sh",
         "script/parallels.sh",
         "script/motd.sh",
-        "custom-script.sh",
+        "{{user `custom_script`}}",
         "script/minimize.sh",
         "script/cleanup.sh"
       ],
@@ -185,7 +185,7 @@
     "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
     "cleanup_pause": "",
     "cpus": "1",
-    "custom_script": ".",
+    "custom_script": "custom-script.sh",
     "desktop": "false",
     "disk_size": "65536",
     "ftp_proxy": "{{env `ftp_proxy`}}",


### PR DESCRIPTION
Use of the existing `custom_script` variable to point to a user defined path for more flexibility.

By default, if not changed, the variable points to the existing `custom_script.sh` of root dir, so default behavior is unchanged.
