### PR TITLE
Zero all the filesystems

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
 SSH_USER=${SSH_USERNAME:-vagrant}
+DISK_USAGE_BEFORE_CLEANUP=$(df -h)
 
 # Make sure udev does not block our network - http://6.ptmc.org/?p=164
 echo "==> Cleaning up udev rules"
@@ -34,9 +35,6 @@ fi
 # Add delay to prevent "vagrant reload" from failing
 echo "pre-up sleep 2" >> /etc/network/interfaces
 
-echo "==> Cleaning up tmp"
-rm -rf /tmp/*
-
 # Cleanup apt cache
 apt-get -y autoremove --purge
 apt-get -y clean
@@ -45,7 +43,8 @@ apt-get -y autoclean
 echo "==> Installed packages"
 dpkg --get-selections | grep -v deinstall
 
-DISK_USAGE_BEFORE_CLEANUP=$(df -h)
+echo "==> Cleaning up tmp"
+rm -rf /tmp/*
 
 # Remove Bash history
 unset HISTFILE
@@ -60,17 +59,13 @@ echo "==> Clearing last login information"
 >/var/log/wtmp
 >/var/log/btmp
 
-# Whiteout root
-count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
-let count--
-dd if=/dev/zero of=/tmp/whitespace bs=1024 count=$count
-rm /tmp/whitespace
-
-# Whiteout /boot
-count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
-let count--
-dd if=/dev/zero of=/boot/whitespace bs=1024 count=$count
-rm /boot/whitespace
+# Whiteout filesystems
+for fs in $(df -h | tail -n +2 | awk '!/^vagrant/ { print $6 }'); do
+    count=$(df --sync -kP $fs | tail -n1  | awk -F ' ' '{print $4}')
+    let count--
+    dd if=/dev/zero of=$fs/whitespace bs=1024 count=$count
+    rm -f $fs/whitespace
+done
 
 echo '==> Clear out swap and disable until reboot'
 set +e
@@ -90,15 +85,17 @@ if [ "x${swapuuid}" != "x" ]; then
 fi
 
 # Zero out the free space to save space in the final image
-dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
-rm -f /EMPTY
+for fs in $(df -h | tail -n +2 | awk '!/^vagrant/ { print $6 }'); do
+    dd if=/dev/zero of=$fs/EMPTY bs=1M || echo "dd exit code $? is suppressed"
+    rm -f $fs/EMPTY
+done
 
 # Make sure we wait until all the data is written to disk, otherwise
 # Packer might quite too early before the large files are deleted
 sync
 
 echo "==> Disk usage before cleanup"
-echo ${DISK_USAGE_BEFORE_CLEANUP}
+echo "${DISK_USAGE_BEFORE_CLEANUP}"
 
 echo "==> Disk usage after cleanup"
 df -h


### PR DESCRIPTION
Ubuntu boxes have a number of filesystems.  Shouldn't they all be zero'd, except for the vagrant shared disk?
```
Filesystem                    Size  Used Avail Use% Mounted on
udev                          2.0G     0  2.0G   0% /dev
tmpfs                         396M  5.6M  390M   2% /run
/dev/mapper/vagrant--vg-root   35G  1.2G   32G   4% /
tmpfs                         2.0G     0  2.0G   0% /dev/shm
tmpfs                         5.0M     0  5.0M   0% /run/lock
tmpfs                         2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/sda1                     472M   56M  393M  13% /boot
vagrant                       233G  216G   17G  93% /vagrant
tmpfs                         396M     0  396M   0% /run/user/1000
```

This helps solve https://github.com/boxcutter/ubuntu/issues/91

Also, report disk usage properly by quoting the original df output.

BTW, it seems to me that there are two different mechanisms here for zeroing the disk.  I would think we only need one, but my experiments were inconclusive, so I am keeping both.