### PR TITLE
Use virtio for much better network performance

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -85,6 +85,9 @@
       "type": "virtualbox-iso",
       "vboxmanage": [
         [
+          "modifyvm", "{{.Name}}", "--nictype1", "virtio"
+        ],
+        [
           "modifyvm", "{{.Name}}", "--memory", "{{ user `memory` }}"
         ],
         [


### PR DESCRIPTION
I don't know if this setting is appropriate for everyone.  On my Mac, without this setting, the network would inexplicably freeze at certain points in the process, sometimes for up to 10 minutes.  With this setting, that never happens, and boxes build much faster.

I can make this an option if you prefer.