### PR TITLE
Removing machine specific reference

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -200,7 +200,6 @@
     "iso_checksum": "70db69379816b91eb01559212ae474a36ecec9ef",
     "iso_checksum_type": "sha1",
     "iso_name": "ubuntu-16.04-server-amd64.iso",
-    "iso_path": "/Volumes/Storage/software/ubuntu",
     "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
     "locale": "en_US",
     "memory": "512",


### PR DESCRIPTION
This line seems to be machine specific and not required. 

    "iso_path": "/Volumes/Storage/software/ubuntu",

as it leads to this error

    virtualbox-iso: Error downloading: stat /Volumes/Storage/software/ubuntu/*.iso: no such file or directory