### PR TITLE
UTF-8 default for multi-language/character display

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -202,7 +202,7 @@
     "iso_name": "ubuntu-16.04-server-amd64.iso",
     "iso_path": "/Volumes/Storage/software/ubuntu",
     "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
-    "locale": "en_US",
+    "locale": "en_US.UTF-8",
     "memory": "512",
     "no_proxy": "{{env `no_proxy`}}",
     "parallels_guest_os_type": "ubuntu",


### PR DESCRIPTION
This should also fix a bug where Gnome Terminal won't open in the -desktop variants due to the "invalid" en_US locale that it doesn't understand, while it likes en_US.UTF-8.