### PR TITLE
Fix default `vm_name`

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -216,7 +216,7 @@
     "vagrantfile_template": "",
     "version": "0.1.0",
     "virtualbox_guest_os_type": "Ubuntu_64",
-    "vm_name": "ubuntu1404",
+    "vm_name": "ubuntu1604",
     "vmware_guest_os_type": "ubuntu-64"
   }
 }


### PR DESCRIPTION
Default `vm_name` should be reference 1604 as all the other defaults