### PR TITLE
missing machine types

### DIFF
--- a/ubuntu1610-i386.json
+++ b/ubuntu1610-i386.json
@@ -10,4 +10,7 @@
   "memory": "512",
   "preseed" : "preseed.cfg",
   "boot_command_prefix": "<esc><esc><enter><wait>"
+  "vmware_guest_os_type": "ubuntu",
+  "virtualbox_guest_os_type": "Ubuntu",
+  "parallels_guest_os_type": "ubuntu"
 }

--- a/ubuntu1610-i386.json
+++ b/ubuntu1610-i386.json
@@ -9,7 +9,7 @@
   "iso_url": "http://releases.ubuntu.com/16.10/ubuntu-16.10-server-i386.iso",
   "memory": "512",
   "preseed" : "preseed.cfg",
-  "boot_command_prefix": "<esc><esc><enter><wait>"
+  "boot_command_prefix": "<esc><esc><enter><wait>",
   "vmware_guest_os_type": "ubuntu",
   "virtualbox_guest_os_type": "Ubuntu",
   "parallels_guest_os_type": "ubuntu"


### PR DESCRIPTION
in the actual ubuntu i386 json file the machine type is missing. Because of the default values in the inheriting ubuntu.json "Ubuntu 64" is used as machine type. 
Older i386 ubuntu json files did have the machine type set. 