### PR TITLE
Install open-vm-tools-desktop package for Ubuntu Desktop variants

### DIFF
--- a/script/vmware.sh
+++ b/script/vmware.sh
@@ -6,6 +6,12 @@ function install_open_vm_tools {
     echo "==> Installing Open VM Tools"
     # Install open-vm-tools so we can mount shared folders
     apt-get install -y open-vm-tools
+
+    # Install open-vm-tools-desktop so we can copy/paste, resize, etc..
+    if [[ "$DESKTOP" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
+        apt-get install -y open-vm-tools-desktop
+    fi
+
     # Add /mnt/hgfs so the mount works automatically with Vagrant
     mkdir /mnt/hgfs
 }


### PR DESCRIPTION
This PR additionally installs the `open-vm-tools-desktop` package for Ubuntu Desktop boxes.

From the [open-vm-tools](https://github.com/vmware/open-vm-tools) README:

> NOTE: Most of the Linux distributions ship two open-vm-tools packages, "open-vm-tools" and "open-vm-tools-desktop". "open-vm-tools" is the core package without any dependencies on X libraries and "open-vm-tools-desktop" is an additional package with dependencies on "open-vm-tools" core package and X libraries.

Without the desktop integration the desktop VM is barely usable, e.g. copy/paste and resizing does not work. Installing the `open-vm-tools-desktop` package after the fact during `vagrant provision` is not really a good workaround as it requires a restart. 

=> so the best way I found was to install it in the basebox, as there is already a place for it. It seems it was just missing there right next to the `open-vm-tools` (see diff)...

Happily using this since a few months now and it works reliably.

Tested with Ubuntu 16.04 Desktop.