### PR TITLE
Upgrade to Ubuntu 16.04.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repository contains [Packer](https://packer.io/) templates for creating Ubu
 
 * [Ubuntu Server 16.10 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610)
 * [Ubuntu Desktop 16.10 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610-desktop)
-* [Ubuntu Server 16.04.1 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604)
-* [Ubuntu Desktop 16.04.1 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-desktop)
+* [Ubuntu Server 16.04.3 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604)
+* [Ubuntu Desktop 16.04.3 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-desktop)
 * [Ubuntu Server 14.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404)
 * [Ubuntu Desktop 14.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404-desktop)
 * [Ubuntu Server 12.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1204)
@@ -20,7 +20,7 @@ This repository contains [Packer](https://packer.io/) templates for creating Ubu
 32-bit boxes:
 
 * [Ubuntu Server 16.10 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610-i386)
-* [Ubuntu Server 16.04.1 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-i386)
+* [Ubuntu Server 16.04.3 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-i386)
 * [Ubuntu Server 14.04.5 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404-i386)
 * [Ubuntu Server 12.04.5 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1204-i386)
 

--- a/bin/register_atlas.sh
+++ b/bin/register_atlas.sh
@@ -74,7 +74,7 @@ get_short_description() {
         PRETTY_VERSION="16.10 Yakkety Yak"
         ;;
     16.04)
-        PRETTY_VERSION="16.04.1 Xenial Xerus"
+        PRETTY_VERSION="16.04.3 Xenial Xerus"
         ;;
     15.10)
         PRETTY_VERSION="15.10 Wily Werewolf"
@@ -128,7 +128,7 @@ create_description() {
         PRETTY_VERSION="16.10 Yakkety Yak"
         ;;
     16.04)
-        PRETTY_VERSION="16.04.1 Xenial Xerus"
+        PRETTY_VERSION="16.04.3 Xenial Xerus"
         ;;
     15.10)
         PRETTY_VERSION="15.10 Wily Werewolf"

--- a/ubuntu1604-desktop.json
+++ b/ubuntu1604-desktop.json
@@ -5,10 +5,10 @@
   "locale": "en_US.UTF-8",
   "cpus": "1",
   "disk_size": "130048",
-  "iso_checksum": "de5ee8665048f009577763efbf4a6f0558833e59",
+  "iso_checksum": "f3532991e031cae75bcf5e695afb844dd278fff9",
   "iso_checksum_type": "sha1",
-  "iso_name": "ubuntu-16.04.1-server-amd64.iso",
-  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
+  "iso_name": "ubuntu-16.04.3-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso",
   "memory": "1024",
   "preseed": "preseed.cfg",
   "vagrantfile_template": "tpl/vagrantfile-ubuntu1604-desktop.tpl"

--- a/ubuntu1604.json
+++ b/ubuntu1604.json
@@ -3,10 +3,10 @@
   "vm_name": "ubuntu1604",
   "cpus": "1",
   "disk_size": "65536",
-  "iso_checksum": "f529548fa7468f2d8413b8427d8e383b830df5f6",
+  "iso_checksum": "f3532991e031cae75bcf5e695afb844dd278fff9",
   "iso_checksum_type": "sha1",
-  "iso_name": "ubuntu-16.04.2-server-amd64.iso",
-  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
+  "iso_name": "ubuntu-16.04.3-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso",
   "memory": "512",
   "preseed" : "preseed.cfg"
 }


### PR DESCRIPTION
In order to build new Ubuntu 16.04 Vagrant Boxes I had to upgrade all .json files to support Ubuntu 16.04.3. This is done for server and desktop versions.

Signed-off-by: Dieter Reuter dieter.reuter@me.com