### PR TITLE
Fix documentation links to point to vagrant cloud for box-cutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ This repository contains [Packer](https://packer.io/) templates for creating Ubu
 
 64-bit boxes:
 
-* [Ubuntu Server 16.10 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610)
-* [Ubuntu Desktop 16.10 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610-desktop)
-* [Ubuntu Server 16.04.3 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604)
-* [Ubuntu Desktop 16.04.3 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-desktop)
-* [Ubuntu Server 14.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404)
-* [Ubuntu Desktop 14.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404-desktop)
-* [Ubuntu Server 12.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1204)
-* [Ubuntu Desktop 12.04.5 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1204-desktop)
+* [Ubuntu Server 16.10 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1610)
+* [Ubuntu Desktop 16.10 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1610-desktop)
+* [Ubuntu Server 16.04.3 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1604)
+* [Ubuntu Desktop 16.04.3 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1604-desktop)
+* [Ubuntu Server 14.04.5 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1404)
+* [Ubuntu Desktop 14.04.5 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1404-desktop)
+* [Ubuntu Server 12.04.5 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1204)
+* [Ubuntu Desktop 12.04.5 (64-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1204-desktop)
 
 32-bit boxes:
 
-* [Ubuntu Server 16.10 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1610-i386)
-* [Ubuntu Server 16.04.3 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1604-i386)
-* [Ubuntu Server 14.04.5 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404-i386)
-* [Ubuntu Server 12.04.5 (32-bit)](https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1204-i386)
+* [Ubuntu Server 16.10 (32-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1610-i386)
+* [Ubuntu Server 16.04.3 (32-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1604-i386)
+* [Ubuntu Server 14.04.5 (32-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1404-i386)
+* [Ubuntu Server 12.04.5 (32-bit)](https://app.vagrantup.com/box-cutter/boxes/ubuntu1204-i386)
 
 ## Building the Vagrant boxes with Packer
 


### PR DESCRIPTION
#125 is closed with this patch