### PR TITLE
Add support for Packer 1.1: set expect_disconnect to true.

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -114,7 +114,7 @@
         "passwd/user-password={{ user `ssh_password` }} ",
         "passwd/user-password-again={{ user `ssh_password` }} ",
         "passwd/username={{ user `ssh_username` }} ",
-        "initrd=/install/initrd.gz -- <wait><enter>" 
+        "initrd=/install/initrd.gz -- <wait><enter>"
       ],
       "disk_size": "{{ user `disk_size` }}",
       "floppy_files": [
@@ -184,7 +184,8 @@
         "script/minimize.sh",
         "script/cleanup.sh"
       ],
-      "type": "shell"
+      "type": "shell",
+      "expect_disconnect": "true"
     }
   ],
   "variables": {
@@ -222,4 +223,3 @@
     "vmware_guest_os_type": "ubuntu-64"
   }
 }
-


### PR DESCRIPTION
Otherwise update.sh will fail because the reboot disconnects and then packer bails out (see https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#backwards-incompatibilities).