### PR TITLE
default vm_name to ubuntu1604, 16.04 = default iso

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -219,7 +219,7 @@
     "vagrantfile_template": "",
     "version": "0.1.0",
     "virtualbox_guest_os_type": "Ubuntu_64",
-    "vm_name": "ubuntu1404",
+    "vm_name": "ubuntu1604",
     "vmware_guest_os_type": "ubuntu-64"
   }
 }


### PR DESCRIPTION
The vm_name generally gets overridden by the var file, but since the default .iso being used is 16.04, the default vm_name should probably be 1604