### PR TITLE
Update to Ubuntu 18.04.1

### DIFF
--- a/ubuntu1804.json
+++ b/ubuntu1804.json
@@ -3,10 +3,10 @@
   "vm_name": "ubuntu1804",
   "cpus": "1",
   "disk_size": "65536",
-  "iso_checksum": "a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc",
+  "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
   "iso_checksum_type": "sha256",
   "iso_name": "ubuntu-18.04-server-amd64.iso",
-  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04/release/ubuntu-18.04-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04/release/ubuntu-18.04.1-server-amd64.iso",
   "memory": "512",
   "preseed" : "preseed.cfg",
   "boot_command_prefix": "<esc><esc><enter><wait>"


### PR DESCRIPTION
Ubunut 18.04 ISOs have already been removed, this updates to the new ISO location with Ubuntu 18.04.1