### PR TITLE
update iso_name according to iso_url - ubuntu 18.04

### DIFF
--- a/ubuntu1804.json
+++ b/ubuntu1804.json
@@ -5,7 +5,7 @@
   "disk_size": "65536",
   "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
   "iso_checksum_type": "sha256",
-  "iso_name": "ubuntu-18.04-server-amd64.iso",
+  "iso_name": "ubuntu-18.04.1-server-amd64.iso",
   "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04/release/ubuntu-18.04.1-server-amd64.iso",
   "memory": "512",
   "preseed" : "preseed.cfg",


### PR DESCRIPTION
I think someone forget to update iso_name according to iso_url variable