### PR TITLE
Fix package config issues with ubuntu1604-desktop build

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -175,8 +175,8 @@
       ],
       "execute_command": "echo '{{ user `ssh_password` }}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
-        "script/update.sh",
         "script/desktop.sh",
+        "script/update.sh",
         "script/vagrant.sh",
         "script/sshd.sh",
         "script/vmware.sh",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -161,6 +161,7 @@
     {
       "environment_vars": [
         "CLEANUP_PAUSE={{user `cleanup_pause`}}",
+        "DEBIAN_FRONTEND=noninteractive",
         "DESKTOP={{user `desktop`}}",
         "UPDATE={{user `update`}}",
         "INSTALL_VAGRANT_KEY={{user `install_vagrant_key`}}",


### PR DESCRIPTION
These two issues were preventing boxes built from this template from being provisioned with Chef due to manual intervention required to fix misconfigured packages. Fixes #141, Fixes #148.