### PR TITLE
Remove redundant wipe of free space on root partition

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -16,7 +16,7 @@ fi
 # Ubuntu 12.04 & 14.04
 if [ -d "/var/lib/dhcp" ]; then
     rm /var/lib/dhcp/*
-fi 
+fi
 
 UBUNTU_VERSION=$(lsb_release -sr)
 # Add delay to prevent "vagrant reload" from failing
@@ -45,12 +45,6 @@ echo "==> Clearing last login information"
 >/var/log/lastlog
 >/var/log/wtmp
 >/var/log/btmp
-
-# Whiteout root
-count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
-let count--
-dd if=/dev/zero of=/tmp/whitespace bs=1024 count=$count
-rm /tmp/whitespace
 
 # Whiteout /boot
 count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')


### PR DESCRIPTION
All the project's preeseed files use the "atomic" partitioning scheme,
which puts all files (except boot) on a single partition. Therefore,
/tmp is the same as / and wiping both adds unecessary build time.