### PR TITLE
add ubuntu 1804 desktop setting

### DIFF
--- a/script/desktop.sh
+++ b/script/desktop.sh
@@ -26,7 +26,7 @@ if [[ $DISTRIB_RELEASE == 12.04 ]]; then
 
     configure_ubuntu1204_autologin
 
-elif [[ $DISTRIB_RELEASE == 14.04 || $DISTRIB_RELEASE == 15.04 || $DISTRIB_RELEASE == 16.04 || $DISTRIB_RELEASE == 16.10 || $DISTRIB_RELEASE == 17.04 ]]; then
+elif [[ $DISTRIB_RELEASE == 14.04 || $DISTRIB_RELEASE == 15.04 || $DISTRIB_RELEASE == 16.04 || $DISTRIB_RELEASE == 16.10 || $DISTRIB_RELEASE == 17.04 || $DISTRIB_RELEASE == 18.04 ]]; then
     echo "==> Installing ubuntu-desktop"
     apt-get install -y ubuntu-desktop
 

--- a/tpl/vagrantfile-ubuntu1804-desktop.tpl
+++ b/tpl/vagrantfile-ubuntu1804-desktop.tpl
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-ubuntu1804-desktop"
+    config.vm.box = "ubuntu1804-desktop"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = true
+        v.customize ["modifyvm", :id, "--memory", 1024]
+        v.customize ["modifyvm", :id, "--cpus", 1]
+        v.customize ["modifyvm", :id, "--vram", "256"]
+        v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+        v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    end
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.gui = true
+        v.vmx["memsize"] = "1024"
+        v.vmx["numvcpus"] = "1"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.vmx["ethernet0.virtualDev"] = "vmxnet3"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
+      end
+    end
+end

--- a/ubuntu1804-desktop.json
+++ b/ubuntu1804-desktop.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu1804-desktop.json ubuntu.json`",
+  "vm_name": "ubuntu1804-desktop",
+  "desktop": "true",
+  "locale": "en_US.UTF-8",
+  "cpus": "1",
+  "disk_size": "130048",
+  "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
+  "iso_checksum_type": "sha256",
+  "iso_name": "ubuntu-18.04.1-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04/release/ubuntu-18.04.1-server-amd64.iso",
+  "memory": "1024",
+  "preseed" : "preseed.cfg",
+  "boot_command_prefix": "<esc><esc><enter><wait>",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu1804-desktop.tpl"
+}


### PR DESCRIPTION
I tried packer script for Ubuntu1804 desktop. Releted Issue #149 .

I tried first, made `ubuntu1804-desktop.json` from copy of `ubuntu1704-desktop.json`.
But stop at languege selection section.

I seemed to work well if I change settings below on desktop.json

#### ubuntu1804-desktop.json

``` json
 "preseed" : "preseed.cfg",
 "boot_command_prefix": "<esc><esc><enter><wait>",
```
  
# Confirmed
- [x] `packer build -only= virtualbox-iso -var-file=ubuntu1804-desktop.json ubuntu.json` was successful.
- [x] `vagrant box add ubuntu1804-desktop ubuntu1804-desktop.box` was successful.
- [x] `vagrant up` was successful and GUI login user vagrant was successful.
- [x] `vagrant ssh` was successful and connected user vagrant.

I made this PR, but I can't implement test spec. I want someone's help.