### PR TITLE
Fix typo that disabled autologin for Ubuntu 18.04

### DIFF
--- a/script/desktop.sh
+++ b/script/desktop.sh
@@ -14,7 +14,7 @@ apt-get install -y ubuntu-desktop
 
 USERNAME=${SSH_USER}
 LIGHTDM_CONFIG=/etc/lightdm/lightdm.conf
-GDM_CUSTOM_CONFIG=/etc/gdm/custom.conf
+GDM_CUSTOM_CONFIG=/etc/gdm3/custom.conf
 
 mkdir -p $(dirname ${GDM_CUSTOM_CONFIG})
 echo "[daemon]" >> $GDM_CUSTOM_CONFIG


### PR DESCRIPTION
Noticed that autologin wasn't working for Ubuntu 18.04. Turned out in my last PR I made a typo. This fixes it.