### PR TITLE
Fix deliver make target

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ which builds Ubuntu 18.04 by default.
 For example, to build Ubuntu 18.04, use the following:
 
     $ packer build -var-file=ubuntu1804.json ubuntu.json
-    
+
 If you want to make boxes for a specific desktop virtualization platform, use the `-only`
 parameter.  For example, to build Ubuntu 18.04 for VirtualBox:
 

--- a/bin/box
+++ b/bin/box
@@ -47,7 +47,7 @@ test() {
 }
 
 build() {
-  bin/build-box "$@"  
+  bin/build-box "$@"
 }
 
 # main

--- a/bin/build-box
+++ b/bin/build-box
@@ -42,7 +42,7 @@ args() {
     only=parallels-iso
   fi
   if [ -n "${only}" ]; then
-    only="-only=${only}"      
+    only="-only=${only}"
   fi
   packer_template=${3:-ubuntu.json}
 }

--- a/bin/bump.sh
+++ b/bin/bump.sh
@@ -84,8 +84,8 @@ patch() {
 main() {
     CURRENT_VERSION=$(cat VERSION)
     VERSION_LIST=($(echo ${CURRENT_VERSION} | tr '.' ' '))
-    MAJOR_VERSION=${VERSION_LIST[0]} 
-    MINOR_VERSION=${VERSION_LIST[1]} 
+    MAJOR_VERSION=${VERSION_LIST[0]}
+    MINOR_VERSION=${VERSION_LIST[1]}
     PATCH_VERSION=${VERSION_LIST[2]}
     args "$@"
 }

--- a/script/vmware.sh
+++ b/script/vmware.sh
@@ -60,10 +60,10 @@ if [[ $PACKER_BUILDER_TYPE =~ vmware ]]; then
         install_vmware_tools
         # Ensure that VMWare Tools recompiles kernel modules
         echo "answer AUTO_KMODS_ENABLED yes" >> /etc/vmware-tools/locations
-      else 
+      else
         install_open_vm_tools
       fi
     else
       install_vmware_tools
-    fi 
+    fi
 fi

--- a/tpl/vagrantfile-ubuntu1404-desktop.tpl
+++ b/tpl/vagrantfile-ubuntu1404-desktop.tpl
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
     config.vm.define "vagrant-ubuntu1404-desktop"
     config.vm.box = "ubuntu1404-desktop"
- 
+
     config.vm.provider :virtualbox do |v, override|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", 1024]


### PR DESCRIPTION
The deliver make target doesn't quite work at the moment.

I fixed it in a way that one can provide the username and access token for vagrantup and have the boxes deployed to this account (by uploading them to app.vagrantup.com).