### PR TITLE
Update iso_url for ubuntu1404

### DIFF
--- a/ubuntu1404.json
+++ b/ubuntu1404.json
@@ -3,10 +3,10 @@
   "vm_name": "ubuntu1404",
   "cpus": "1",
   "disk_size": "65536",
-  "iso_checksum": "5e567024c385cc8f90c83d6763c6e4f1cd5deb6f",
+  "iso_checksum": "13bfe163ca8ad8a6e5676b0460ca60d03387ec24",
   "iso_checksum_type": "sha1",
-  "iso_name": "ubuntu-14.04.5-server-amd64.iso",
-  "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso",
+  "iso_name": "ubuntu-14.04.6-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-server-amd64.iso",
   "memory": "512",
   "preseed" : "preseed.cfg",
   "boot_command_prefix": "<esc><esc><enter><wait>"


### PR DESCRIPTION
Current checksum for ubuntu1404 is wrong, so you cannot build images.  
Also, the iso file is a little bit old.
This PR will update them so that you can build ubuntu1404 image, with the latest iso file.