### PR TITLE
Blank /etc/machine-id so machines generate a new ID on first boot

### DIFF
--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -18,6 +18,13 @@ if [ -d "/var/lib/dhcp" ]; then
     rm /var/lib/dhcp/*
 fi
 
+# Blank machine-id (DUID) so machines get unique ID generated on boot.
+# https://www.freedesktop.org/software/systemd/man/machine-id.html#Initialization
+echo "==> Blanking systemd machine-id"
+if [ -f "/etc/machine-id" ]; then
+    truncate -s 0 "/etc/machine-id"
+fi
+
 # Add delay to prevent "vagrant reload" from failing
 echo "pre-up sleep 2" >> /etc/network/interfaces
 


### PR DESCRIPTION
By default, the machine-id is used as the DUID to identify the machine to a DHCP server. If two machines have the same machine-id, they are assigned the same IP-Address.

Same bug in chef/bento: [#1062](https://github.com/chef/bento/issues/1062)
Relevant systemd documentation: [ machine-id(5)](https://www.freedesktop.org/software/systemd/man/machine-id.html#Initialization)


