### PR TITLE
Enabled headless mode by default

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -199,7 +199,7 @@
     "desktop": "false",
     "disk_size": "65536",
     "ftp_proxy": "{{env `ftp_proxy`}}",
-    "headless": "false",
+    "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",


### PR DESCRIPTION
Use case: so one can easily SSH into a server and build a box without requiring X11 forwarding nor configuration changes