### PR TITLE
Use path to the box file for the test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use the `bin/box test` subcommand to run the automated Serverspec tests.
 For example to execute the tests for the Ubuntu 20.04 box on VirtualBox, use
 the following:
 
-    bin/box test ubuntu2004 virtualbox
+    bin/box test box/virtualbox/ubuntu2004-0.1.0.box virtualbox
 
 Similarly, to perform exploratory testing on the VirtualBox image via ssh,
 run the following command:


### PR DESCRIPTION
I guess whereas the build command uses the .json spec file basename as an argument, instead, the test command will use the path to the box file