### PR TITLE
Add ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use the `bin/box test` subcommand to run the automated Serverspec tests.
 For example to execute the tests for the Ubuntu 20.04 box on VirtualBox, use
 the following:
 
-    bin/box test ubuntu2004 virtualbox
+    bin/box test box/virtualbox/ubuntu2004-0.1.0.box virtualbox
 
 Similarly, to perform exploratory testing on the VirtualBox image via ssh,
 run the following command:

--- a/script/desktop.sh
+++ b/script/desktop.sh
@@ -23,6 +23,7 @@ if [ -f $GDM_CUSTOM_CONFIG ]; then
     echo "# Enabling automatic login" >> $GDM_CUSTOM_CONFIG
     echo "AutomaticLoginEnable = true" >> $GDM_CUSTOM_CONFIG
     echo "AutomaticLogin = ${USERNAME}" >> $GDM_CUSTOM_CONFIG
+    echo "WaylandEnable = false" >> $GDM_CUSTOM_CONFIG
 fi
 
 if [ -f $LIGHTDM_CONFIG ]; then

--- a/tpl/vagrantfile-ubuntu2204-desktop.tpl
+++ b/tpl/vagrantfile-ubuntu2204-desktop.tpl
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-ubuntu2204-desktop"
+    config.vm.box = "ubuntu2204-desktop"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = true
+        v.customize ["modifyvm", :id, "--memory", 1024]
+        v.customize ["modifyvm", :id, "--cpus", 1]
+        v.customize ["modifyvm", :id, "--vram", "256"]
+        v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+        v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    end
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.gui = true
+        v.vmx["memsize"] = "1024"
+        v.vmx["numvcpus"] = "1"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
+      end
+    end
+end

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -5,8 +5,9 @@
       "boot_wait": "5s",
       "boot_command": [
         "{{ user `boot_command_prefix` }}",
-        "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
-        "<wait><enter>"
+        "autoinstall ds='nocloud-net;s=http://<wait>{{ .HTTPIP }}<wait>:{{ .HTTPPort }}/<wait>'  ---",
+        "<wait><enter>",
+        "{{ user `boot_command_suffix` }}"
       ],
       "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "{{ user `vmware_guest_os_type` }}",
@@ -37,8 +38,9 @@
       "boot_wait": "5s",
       "boot_command": [
         "{{ user `boot_command_prefix` }}",
-        "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
-        "<wait><enter>"
+        "autoinstall ds='nocloud-net;s=http://<wait>{{ .HTTPIP }}<wait>:{{ .HTTPPort }}/<wait>'  ---",
+        "<wait><enter>",
+        "{{ user `boot_command_suffix` }}"
       ],
       "disk_size": "{{ user `disk_size` }}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
@@ -77,8 +79,9 @@
       "boot_wait": "5s",
       "boot_command": [
         "{{ user `boot_command_prefix` }}",
-        "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
-        "<wait><enter>"
+        "autoinstall ds='nocloud-net;s=http://<wait>{{ .HTTPIP }}<wait>:{{ .HTTPPort }}/<wait>'  ---",
+        "<wait><enter>",
+        "{{ user `boot_command_suffix` }}"
       ],
       "disk_size": "{{ user `disk_size` }}",
       "floppy_files": [
@@ -155,6 +158,7 @@
   ],
   "variables": {
     "boot_command_prefix": "<enter><enter><f6><esc><wait>",
+    "boot_command_suffix": "",
     "cleanup_pause": "",
     "cpus": "1",
     "custom_script": "custom-script.sh",

--- a/ubuntu2004-desktop.json
+++ b/ubuntu2004-desktop.json
@@ -4,9 +4,9 @@
   "desktop": "true",
   "cpus": "1",
   "disk_size": "130048",
-  "iso_checksum": "sha256:d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423",
+  "iso_checksum": "sha256:28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad",
   "iso_name": "ubuntu-20.04.2-live-server-amd64.iso",
-  "iso_url": "http://releases.ubuntu.com/20.04/ubuntu-20.04.2-live-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso",
   "memory": "1024",
   "vagrantfile_template": "tpl/vagrantfile-ubuntu2004-desktop.tpl"
 }

--- a/ubuntu2204-desktop.json
+++ b/ubuntu2204-desktop.json
@@ -8,7 +8,7 @@
   "iso_name": "ubuntu-22.04-live-server-amd64.iso",
   "iso_url": "http://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
   "memory": "1024",
-  "vagrantfile_template": "tpl/vagrantfile-ubuntu2004-desktop.tpl",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu2204-desktop.tpl",
   "boot_command_prefix": "c<wait>set gfxpayload=keep<enter><wait>linux /casper/vmlinuz quiet <wait>",
   "boot_command_suffix": "initrd /casper/initrd<wait><enter>boot<enter><wait>"
 }

--- a/ubuntu2204-desktop.json
+++ b/ubuntu2204-desktop.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu2204-desktop.json ubuntu.json`",
+  "vm_name": "ubuntu2204-desktop",
+  "desktop": "true",
+  "cpus": "1",
+  "disk_size": "130048",
+  "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
+  "iso_name": "ubuntu-22.04-live-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
+  "memory": "1024",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu2004-desktop.tpl",
+    "boot_command_prefix": "c<wait>set gfxpayload=keep<enter><wait>linux /casper/vmlinuz quiet <wait>",
+  "boot_command_suffix": "initrd /casper/initrd<wait><enter>boot<enter><wait>"
+}

--- a/ubuntu2204-desktop.json
+++ b/ubuntu2204-desktop.json
@@ -9,6 +9,6 @@
   "iso_url": "http://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
   "memory": "1024",
   "vagrantfile_template": "tpl/vagrantfile-ubuntu2004-desktop.tpl",
-    "boot_command_prefix": "c<wait>set gfxpayload=keep<enter><wait>linux /casper/vmlinuz quiet <wait>",
+  "boot_command_prefix": "c<wait>set gfxpayload=keep<enter><wait>linux /casper/vmlinuz quiet <wait>",
   "boot_command_suffix": "initrd /casper/initrd<wait><enter>boot<enter><wait>"
 }


### PR DESCRIPTION
This should add Ubuntu 22.04, newer LTS.

Hoping that the boot_command adjustments that seemed needed won't break older release boxes builds